### PR TITLE
fix: Avoid apply error when no existing storage account is given

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,8 @@ locals {
   function_app_name    = "${local.name}-func"
   storage_account_name = var.storage_account.app_short_name != null ? "${var.system_short_name}${var.storage_account.app_short_name}${var.environment}st" : null
 
-  existing_storage_account_name       = var.storage_account.existing_account.azurerm_storage_account.name
-  existing_storage_account_access_key = var.storage_account.existing_account.azurerm_storage_account.primary_access_key
+  existing_storage_account_name       = try(var.storage_account.existing_account.azurerm_storage_account.name, null)
+  existing_storage_account_access_key = try(var.storage_account.existing_account.azurerm_storage_account.primary_access_key, null)
 }
 
 module "storageaccount" {


### PR DESCRIPTION
Example of how it will fail before this PR: https://github.com/EnergiMidt/ao-arbeidsordre-iac/actions/runs/6967449920/job/18973149586?pr=103