### PR TITLE
feat: Added support for isolated runtime for dotnet functions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,9 +109,10 @@ resource "azurerm_windows_function_app" "app" {
   }
   site_config {
     application_stack {
-      dotnet_version = var.runtime.dotnet_version
-      java_version   = var.runtime.java_version
-      node_version   = var.runtime.node_version
+      dotnet_version              = var.runtime.dotnet_version
+      use_dotnet_isolated_runtime = var.runtime.dotnet_isolated
+      java_version                = var.runtime.java_version
+      node_version                = var.runtime.node_version
     }
     dynamic "cors" {
       for_each = var.cors[*]

--- a/variables.tf
+++ b/variables.tf
@@ -113,6 +113,7 @@ variable "runtime" {
   description = "The application runtime versions to use."
   type = object({
     dotnet_version = optional(string)
+    dotnet_isolated= optional(bool)
     java_version   = optional(string)
     node_version   = optional(string)
   })


### PR DESCRIPTION
For å støtte .net 8 og nyere så må funksjoner kjøre isolated.

La til en optional (bool) parameter for å sette "use_dotnet_isolated_runtime"